### PR TITLE
freeze default settings

### DIFF
--- a/lib/onelogin/ruby-saml/settings.rb
+++ b/lib/onelogin/ruby-saml/settings.rb
@@ -5,6 +5,7 @@ module OneLogin
         config = DEFAULTS.merge(overrides)
         config.each do |k,v|
           acc = "#{k.to_s}=".to_sym
+          v = v.dup if v.is_a?(Hash)
           self.send(acc, v) if self.respond_to? acc
         end
         @attribute_consuming_service = AttributeService.new
@@ -111,9 +112,9 @@ module OneLogin
           :embed_sign               => false,
           :digest_method            => XMLSecurity::Document::SHA1,
           :signature_method         => XMLSecurity::Document::SHA1
-        },
+        }.freeze,
         :double_quote_xml_attribute_values         => false,
-      }
+      }.freeze
     end
   end
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -53,12 +53,23 @@ class SettingsTest < Test::Unit::TestCase
       @settings = OneLogin::RubySaml::Settings.new
       @settings.attribute_consuming_service.configure do
         service_name "Test Service"
-        add_attribute :name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name" 
+        add_attribute :name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name"
       end
 
       assert_equal @settings.attribute_consuming_service.configured?, true
       assert_equal @settings.attribute_consuming_service.name, "Test Service"
       assert_equal @settings.attribute_consuming_service.attributes, [{:name => "Name", :name_format => "Name Format", :friendly_name => "Friendly Name" }]
+    end
+
+    context 'default security settings have changed' do
+      setup do
+        @settings.security[:authn_requests_signed] = true
+      end
+
+      should 'not retain old security settings' do
+        @new_settings = OneLogin::RubySaml::Settings.new
+        assert_equal @new_settings.security[:authn_requests_signed], false
+      end
     end
 
   end


### PR DESCRIPTION
## Fixes bug which lets saml settings 'bleed' over from one MSO to another

Note: please also merge this PR which had errors in the spec due to this bug.
https://github.com/Studio3/Mauka/pull/468